### PR TITLE
Add Bitbucket cloud target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for GitLab as a Git provider
+- Support for Bitbucket cloud as a Git provider
 - Support for Helm as a templater
 - Support for Kustomize as a templater
 

--- a/README.md
+++ b/README.md
@@ -32,21 +32,33 @@ deploy-prod:
   image: ghcr.io/neosperience/shipper:main
   environment: prod
   script:
-  - |
-    shipper --templater helm \
-      --repo-kind gitlab \
-      --repo-branch main \
-      --commit-author "$GITLAB_USER_NAME <$GITLAB_USER_EMAIL>" \
-      --commit-message "Deploy new version" \
-      --container-image $CI_REGISTRY_IMAGE \
-      --container-tag  $CI_COMMIT_SHA \
-      --helm-values-file prod/values.yaml \
-      --helm-image-path image.repository \
-      --helm-tag-path image.tag \
-      --gitlab-endpoint $CI_API_V4_URL \
-      --gitlab-key $CI_JOB_TOKEN" \
-      --gitlab-project my-app/deployments
+    - |
+      shipper --templater helm \
+        --repo-kind gitlab \
+        --repo-branch main \
+        --commit-author "$GITLAB_USER_NAME <$GITLAB_USER_EMAIL>" \
+        --commit-message "Deploy new version" \
+        --container-image $CI_REGISTRY_IMAGE \
+        --container-tag  $CI_COMMIT_SHA \
+        --helm-values-file prod/values.yaml \
+        --helm-image-path image.repository \
+        --helm-tag-path image.tag \
+        --gitlab-endpoint $CI_API_V4_URL \
+        --gitlab-key $CI_JOB_TOKEN" \
+        --gitlab-project my-app/deployments
 ```
+
+## Provider notes
+
+### Gitlab
+
+- When creating an access token for shipper, only the permission `api` is needed. (Role depends on your branch permissions, eg. protected branches)
+
+### Bitbucket cloud
+
+- When creating an app password for shipper, only the permissions `repository:read` and `repository:write` are needed.
+- The author string MUST be in the `John Doe <john.doe@example.com>` format or the commit will fail.
+- Bitbucket cloud integration only works with Bitbucket cloud, Bitbucket server has completely different APIs.
 
 ## Contributing
 
@@ -74,13 +86,13 @@ limitations under the License.
 
 <a href="https://www.vecteezy.com/free-vector/ship">Logo by joezhuang on Vecteezy</a>
 
-[Neosperience]: https://neosperience.com
-[ArgoCD]: https://argoproj.github.io/cd
-[Karavel Container Platform]: https://platform.karavel.io
-[Helm]: https://helm.sh
-[Kustomize]: https://kustomize.io
-[GitLab]: https://gitlab.com
-[GitHub]: https://github.com
-[BitBucket]: https://bitbucket.com
-[Golang]: https://go.dev
-[SemVer]: https://semver.org/
+[neosperience]: https://neosperience.com
+[argocd]: https://argoproj.github.io/cd
+[karavel container platform]: https://platform.karavel.io
+[helm]: https://helm.sh
+[kustomize]: https://kustomize.io
+[gitlab]: https://gitlab.com
+[github]: https://github.com
+[bitbucket]: https://bitbucket.com
+[golang]: https://go.dev
+[semver]: https://semver.org/

--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/neosperience/shipper/targets"
+	bitbucket_target "github.com/neosperience/shipper/targets/bitbucket"
 	gitlab_target "github.com/neosperience/shipper/targets/gitlab"
 	helm_templater "github.com/neosperience/shipper/templater/helm"
 	kustomize_templater "github.com/neosperience/shipper/templater/kustomize"
@@ -32,6 +33,14 @@ func app(c *cli.Context) error {
 		assert(apikey != "", "Gitlab API key must be specified when using Gitlab")
 
 		repository = gitlab_target.NewAPIClient(uri, project, apikey)
+	case "bitbucket-cloud":
+		creds := c.String("bitbucket-key")
+		assert(creds != "", "Bitbucket cloud credentials must be specified when using Bitbucket cloud")
+
+		project := c.String("bitbucket-project")
+		assert(project != "", "Bitbucket project path must be specified when using Bitbucket cloud")
+
+		repository = bitbucket_target.NewCloudAPIClient(project, creds)
 	default:
 		return fmt.Errorf("repository option not supported: %s", target)
 	}
@@ -96,7 +105,7 @@ func main() {
 				Name:     "repo-kind",
 				Aliases:  []string{"t"},
 				Value:    "gitlab",
-				Usage:    "Repository type (available: \"gitlab\")",
+				Usage:    "Repository type (available: \"gitlab\", \"bitbucket-cloud\")",
 				EnvVars:  []string{"SHIPPER_REPO_KIND"},
 				Required: true,
 			},
@@ -180,6 +189,19 @@ func main() {
 				Name:    "gitlab-project",
 				Aliases: []string{"gl-pid"},
 				Usage:   "[gitlab] Project ID in \"org/project\" format",
+				EnvVars: []string{"SHIPPER_GITLAB_PROJECT"},
+			},
+			// Bitbucket options
+			&cli.StringFlag{
+				Name:    "bitbucket-key",
+				Aliases: []string{"bb-key"},
+				Usage:   "[bitbucket-cloud] Username/password pair in \"username:password\" format (use app passwords!)",
+				EnvVars: []string{"SHIPPER_GITLAB_KEY"},
+			},
+			&cli.StringFlag{
+				Name:    "bitbucket-project",
+				Aliases: []string{"bb-pid"},
+				Usage:   "[bitbucket-cloud] Project path in \"org/project\" format",
 				EnvVars: []string{"SHIPPER_GITLAB_PROJECT"},
 			},
 		},

--- a/targets/bitbucket/bbcloud.go
+++ b/targets/bitbucket/bbcloud.go
@@ -1,0 +1,88 @@
+package bitbucket_target
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/neosperience/shipper/targets"
+)
+
+// BitbucketCloudRepository commits to a Bitbucket.com repository using the Bitbucket Cloud REST APIs
+type BitbucketCloudRepository struct {
+	baseURI     string
+	projectID   string
+	credentials string
+
+	client *http.Client
+}
+
+// NewCloudAPIClient creates a BitbucketCloudRepository instance
+func NewCloudAPIClient(projectID string, credentials string) *BitbucketCloudRepository {
+	var transport = &http.Transport{
+		IdleConnTimeout: 30 * time.Second,
+	}
+	var client = &http.Client{Transport: transport}
+	return &BitbucketCloudRepository{
+		baseURI:     "https://api.bitbucket.org/2.0",
+		projectID:   projectID,
+		credentials: credentials,
+		client:      client,
+	}
+}
+
+func (bb *BitbucketCloudRepository) Get(path string, ref string) ([]byte, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/repositories/%s/src/%s/%s", bb.baseURI, bb.projectID, ref, path), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(bb.credentials)))
+
+	res, err := bb.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error performing request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("request returned error: %s", body)
+	}
+
+	return ioutil.ReadAll(res.Body)
+}
+
+func (bb *BitbucketCloudRepository) Commit(payload *targets.CommitPayload) error {
+	data := url.Values{}
+	for name, content := range payload.Files {
+		trailName := "/" + strings.TrimLeft(name, "/")
+		data.Set(trailName, string(content))
+	}
+	data.Set("branch", payload.Branch)
+	data.Set("author", payload.Author)
+	data.Set("message", payload.Message)
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/repositories/%s/src", bb.baseURI, bb.projectID), strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(bb.credentials)))
+
+	res, err := bb.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error performing request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(res.Body)
+		return fmt.Errorf("request returned error: %s", body)
+	}
+
+	return nil
+}

--- a/targets/bitbucket/bbcloud_test.go
+++ b/targets/bitbucket/bbcloud_test.go
@@ -1,0 +1,85 @@
+package bitbucket_target
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/neosperience/shipper/targets"
+)
+
+func assertExpected(t *testing.T, val string, expected string, errmsg string) {
+	if val != expected {
+		t.Fatalf("%s [expected=\"%s\" | got=\"%s\"]", errmsg, expected, val)
+	}
+}
+
+func TestCommit(t *testing.T) {
+	testUser := "test-user"
+	testKey := "test-key"
+	commit := targets.NewPayload("test-branch", "test-author <author@example.com>", "Hello")
+	commit.Files.Add(map[string][]byte{
+		"textfile.txt":   []byte("test file"),
+		"binaryfile.jpg": {0xff, 0xd8, 0xff, 0xe0},
+	})
+
+	// Setup test HTTP server/client
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Check authorization key
+		user, key, ok := req.BasicAuth()
+		if !ok {
+			t.Fatal("Invalid or empty HTTP Basic auth header received")
+		}
+		assertExpected(t, user, testUser, "Basic auth user doesn't match expected value")
+		assertExpected(t, key, testKey, "Basic auth password doesn't match expected value")
+
+		err := req.ParseForm()
+		if err != nil {
+			t.Fatal("Could not parse formdata")
+		}
+		assertExpected(t, req.Form.Get("author"), commit.Author, "Form author doesn't match expected commit author")
+		assertExpected(t, req.Form.Get("branch"), commit.Branch, "Form branch doesn't match expected commit branch")
+		assertExpected(t, req.Form.Get("message"), commit.Message, "Form message doesn't match expected commit message")
+	}))
+	defer server.Close()
+	target := NewCloudAPIClient("test-project", fmt.Sprintf("%s:%s", testUser, testKey))
+	target.client = server.Client()
+	target.baseURI = server.URL
+
+	if err := target.Commit(commit); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestGet(t *testing.T) {
+	testUser := "test-user"
+	testKey := "test-key"
+	testData := []byte("hello test here")
+
+	// Setup test HTTP server/client
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Check authorization key
+		user, key, ok := req.BasicAuth()
+		if !ok {
+			t.Fatal("Invalid or empty HTTP Basic auth header received")
+		}
+		assertExpected(t, user, testUser, "Basic auth user doesn't match expected value")
+		assertExpected(t, key, testKey, "Basic auth password doesn't match expected value")
+
+		rw.Write(testData)
+	}))
+	defer server.Close()
+	target := NewCloudAPIClient("test-project", fmt.Sprintf("%s:%s", testUser, testKey))
+	target.client = server.Client()
+	target.baseURI = server.URL
+
+	byt, err := target.Get(testKey, "main")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !bytes.Equal(byt, testData) {
+		t.Fatal("Expected file content is different from retrieved")
+	}
+}


### PR DESCRIPTION
### Description

Add Bitbucket cloud as git provider using the Bitbucket cloud APIs (so this only works with Bitbucket cloud and not Bitbucket server!)

### References

Closes #1

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this or a different PR.
- [x] I have signed off my commits as required by the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] The correct base branch is being used, if not `main`

