### PR TITLE
GitHub git provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for GitHub as a git provider (`--repo-kind github`), works with both hosted GitHub and GitHub Enteprise Server.
+
+### Changed
+
+- Set default value for `--gitlab-endpoint`/`-gl-url` to GitLab.com's API endpoint
+
 ## [0.1.0] - 2022-02-28
 
 ### Added
@@ -16,5 +24,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Helm as a templater
 - Support for Kustomize as a templater
 
-[Unreleased]: https://github.com/neosperience/shipper/compare/0.1.0...HEAD
+[unreleased]: https://github.com/neosperience/shipper/compare/0.1.0...HEAD
 [0.1.0]: https://github.com/neosperience/shipper/releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Shipper automates this by leveraging the native Git provider API (e.g. GitLab, G
 ### Git Providers
 
 - [GitLab] (both self-managed and gitlab.com)
-- [GitHub] (planned)
-- [BitBucket] (planned)
+- [BitBucket] (only BitBucket cloud ie. bitbucket.org)
+- [GitHub] (both GitHub.com and GitHub Enteprise Server)
 
 ### Templaters
 
@@ -56,11 +56,17 @@ deploy-prod:
 
 ### Gitlab
 
-- When creating an access token for shipper, only the permission `api` is needed. (Role depends on your branch permissions, eg. protected branches)
+- When creating a [project access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) for shipper, only the permission `api` is needed. (Role depends on your branch permissions, eg. protected branches)
+
+### GitHub
+
+- When creating a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for shipper, only the permissions `repo` is needed.
+- The author string MUST be in the `John Doe <john.doe@example.com>` format or the commit will fail.
+- The GitHub Cloud API endpoint is `https://api.github.com`, however GitHub Enterprise Server will have something more akin to `https://HOSTNAME/api/v3`
 
 ### Bitbucket cloud
 
-- When creating an app password for shipper, only the permissions `repository:read` and `repository:write` are needed.
+- When creating an [app password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) for shipper, only the permissions `repository:read` and `repository:write` are needed.
 - The author string MUST be in the `John Doe <john.doe@example.com>` format or the commit will fail.
 - Bitbucket cloud integration only works with Bitbucket cloud, Bitbucket server has completely different APIs.
 

--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/neosperience/shipper/targets"
 	bitbucket_target "github.com/neosperience/shipper/targets/bitbucket"
+	github_target "github.com/neosperience/shipper/targets/github"
 	gitlab_target "github.com/neosperience/shipper/targets/gitlab"
 	helm_templater "github.com/neosperience/shipper/templater/helm"
 	kustomize_templater "github.com/neosperience/shipper/templater/kustomize"
@@ -33,6 +34,17 @@ func app(c *cli.Context) error {
 		assert(apikey != "", "Gitlab API key must be specified when using Gitlab")
 
 		repository = gitlab_target.NewAPIClient(uri, project, apikey)
+	case "github":
+		uri := c.String("github-endpoint")
+		assert(uri != "", "GitHub endpoint must be specified when using GitHub")
+
+		project := c.String("github-project")
+		assert(project != "", "GitHub project ID must be specified when using GitHub")
+
+		apikey := c.String("github-key")
+		assert(apikey != "", "GitHub API key must be specified when using GitHub")
+
+		repository = github_target.NewAPIClient(uri, project, apikey)
 	case "bitbucket-cloud":
 		creds := c.String("bitbucket-key")
 		assert(creds != "", "Bitbucket cloud credentials must be specified when using Bitbucket cloud")
@@ -105,7 +117,7 @@ func main() {
 				Name:     "repo-kind",
 				Aliases:  []string{"t"},
 				Value:    "gitlab",
-				Usage:    "Repository type (available: \"gitlab\", \"bitbucket-cloud\")",
+				Usage:    "Repository type (available: \"gitlab\", \"github\", \"bitbucket-cloud\")",
 				EnvVars:  []string{"SHIPPER_REPO_KIND"},
 				Required: true,
 			},
@@ -176,8 +188,9 @@ func main() {
 			&cli.StringFlag{
 				Name:    "gitlab-endpoint",
 				Aliases: []string{"gl-uri"},
-				Usage:   "[gitlab] Gitlab API endpoint, including \"/api/v4/\"",
+				Usage:   "[gitlab] Gitlab API endpoint, including \"/api/v4\"",
 				EnvVars: []string{"SHIPPER_GITLAB_ENDPOINT"},
+				Value:   "https://gitlab.com/api/v4",
 			},
 			&cli.StringFlag{
 				Name:    "gitlab-key",
@@ -190,6 +203,26 @@ func main() {
 				Aliases: []string{"gl-pid"},
 				Usage:   "[gitlab] Project ID in \"org/project\" format",
 				EnvVars: []string{"SHIPPER_GITLAB_PROJECT"},
+			},
+			// GitHub options
+			&cli.StringFlag{
+				Name:    "github-endpoint",
+				Aliases: []string{"gh-uri"},
+				Usage:   "[github] GitHub API endpoint (include \"/api/v3\" if using Enterprise Server)",
+				EnvVars: []string{"SHIPPER_GITHUB_ENDPOINT"},
+				Value:   "https://api.github.com",
+			},
+			&cli.StringFlag{
+				Name:    "github-key",
+				Aliases: []string{"gh-key"},
+				Usage:   "[github] Username/password pair in \"username:password\" format (use a personal access token!)",
+				EnvVars: []string{"SHIPPER_GITHUB_KEY"},
+			},
+			&cli.StringFlag{
+				Name:    "github-project",
+				Aliases: []string{"gh-pid"},
+				Usage:   "[github] Project ID in \"org/project\" format",
+				EnvVars: []string{"SHIPPER_GITHUB_PROJECT"},
 			},
 			// Bitbucket options
 			&cli.StringFlag{

--- a/targets/github/github.go
+++ b/targets/github/github.go
@@ -1,0 +1,156 @@
+package github_target
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/neosperience/shipper/targets"
+)
+
+// GithubRepository commits to a GitHub repository using the GitHub REST Commits APIs
+type GithubRepository struct {
+	baseURI     string
+	projectID   string
+	credentials string
+
+	client *http.Client
+}
+
+// NewAPIClient creates a GithubRepository instance
+func NewAPIClient(uri string, projectID string, credentials string) *GithubRepository {
+	var transport = &http.Transport{
+		IdleConnTimeout: 30 * time.Second,
+	}
+	var client = &http.Client{Transport: transport}
+	return &GithubRepository{
+		baseURI:     uri,
+		projectID:   projectID,
+		credentials: credentials,
+		client:      client,
+	}
+}
+
+func (gh *GithubRepository) Get(path string, ref string) ([]byte, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s", gh.baseURI, gh.projectID, path, url.QueryEscape(ref)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Add("Accept", "application/vnd.github.v3.raw")
+	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(gh.credentials)))
+
+	res, err := gh.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error performing request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(res.Body)
+		return nil, fmt.Errorf("request returned error: %s", body)
+	}
+
+	return ioutil.ReadAll(res.Body)
+}
+
+func (gh *GithubRepository) getFileSHA(path, branch string) (string, bool, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/repos/%s/contents/%s?ref=%s", gh.baseURI, gh.projectID, path, url.QueryEscape(branch)), nil)
+	if err != nil {
+		return "", false, fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Add("Accept", "application/vnd.github.v3+json")
+	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(gh.credentials)))
+
+	res, err := gh.client.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("error performing request: %w", err)
+	}
+	defer res.Body.Close()
+
+	// File not found, file does not exist
+	if res.StatusCode == 404 {
+		return "", false, nil
+	}
+
+	// Error encountered
+	if res.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(res.Body)
+		return "", false, fmt.Errorf("request returned error: %s", body)
+	}
+
+	var fileInfo struct {
+		SHA string `json:"sha"`
+	}
+	err = jsoniter.ConfigFastest.NewDecoder(res.Body).Decode(&fileInfo)
+	if err != nil {
+		return "", false, fmt.Errorf("error decoding request body: %w", err)
+	}
+
+	return fileInfo.SHA, true, nil
+}
+
+type CommitDataAuthor struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type CommitData struct {
+	Message   string           `json:"message"`
+	Content   string           `json:"content"`
+	Branch    string           `json:"branch"`
+	SHA       string           `json:"sha,omitempty"`
+	Committer CommitDataAuthor `json:"committer"`
+}
+
+func (gh *GithubRepository) Commit(payload *targets.CommitPayload) error {
+	author, email := payload.SplitAuthor()
+
+	for path, file := range payload.Files {
+		// Get original file, if exists, for the original file's SHA
+		sha, _, err := gh.getFileSHA(path, payload.Branch)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve file SHA: %w", err)
+		}
+
+		b := new(bytes.Buffer)
+		err = jsoniter.ConfigFastest.NewEncoder(b).Encode(CommitData{
+			Branch:  payload.Branch,
+			Message: payload.Message,
+			Committer: CommitDataAuthor{
+				Name:  author,
+				Email: email,
+			},
+			Content: base64.StdEncoding.EncodeToString(file),
+			SHA:     sha,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to encode commit payload: %w", err)
+		}
+
+		req, err := http.NewRequest("PUT", fmt.Sprintf("%s/repos/%s/contents/%s", gh.baseURI, gh.projectID, path), b)
+		if err != nil {
+			return fmt.Errorf("error creating request: %w", err)
+		}
+		req.Header.Add("Content-Type", "application/json")
+		req.Header.Add("Accept", "application/vnd.github.v3+json")
+		req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(gh.credentials)))
+
+		res, err := gh.client.Do(req)
+		if err != nil {
+			return fmt.Errorf("error performing request: %w", err)
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode >= 400 {
+			body, _ := ioutil.ReadAll(res.Body)
+			return fmt.Errorf("request returned error: %s", body)
+		}
+	}
+
+	return nil
+}

--- a/targets/github/github_test.go
+++ b/targets/github/github_test.go
@@ -1,0 +1,157 @@
+package github_target
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/neosperience/shipper/targets"
+)
+
+func assertExpected(t *testing.T, val string, expected string, errmsg string) {
+	if val != expected {
+		t.Fatalf("%s [expected=\"%s\" | got=\"%s\"]", errmsg, expected, val)
+	}
+}
+
+func TestCommit(t *testing.T) {
+	testUser := "test-user"
+	testKey := "test-key"
+	commit := targets.NewPayload("test-branch", "test-author <author@example.com>", "Hello")
+	commit.Files.Add(map[string][]byte{
+		"textfile.txt":   []byte("test file"),
+		"binaryfile.jpg": {0xff, 0xd8, 0xff, 0xe0},
+	})
+
+	hashes := map[string]string{
+		"textfile.txt": "testsha",
+	}
+
+	// Setup test HTTP server/client
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Check authorization key
+		user, key, ok := req.BasicAuth()
+		if !ok {
+			t.Fatal("Invalid or empty HTTP Basic auth header received")
+		}
+		assertExpected(t, user, testUser, "Basic auth user doesn't match expected value")
+		assertExpected(t, key, testKey, "Basic auth password doesn't match expected value")
+
+		parts := strings.Split(req.URL.Path, "/")
+		file := parts[len(parts)-1]
+
+		// If GET-ting, we're asking for the file info
+		if req.Method == http.MethodGet {
+			sha, ok := hashes[file]
+			if !ok {
+				http.Error(rw, "not found", http.StatusNotFound)
+				return
+			}
+
+			if err := jsoniter.ConfigFastest.NewEncoder(rw).Encode(struct {
+				SHA string `json:"sha"`
+			}{
+				SHA: sha,
+			}); err != nil {
+				t.Fatalf("Failed sending SHA info: %s", err.Error())
+			}
+			return
+		}
+
+		// Must be put PUT-ting
+		var payload CommitData
+		err := jsoniter.ConfigFastest.NewDecoder(req.Body).Decode(&payload)
+		if err != nil {
+			t.Fatalf("Failed decoding request payload: %s", err.Error())
+		}
+
+		byt, err := base64.StdEncoding.DecodeString(payload.Content)
+		if err != nil {
+			t.Fatalf("Failed decoding base64-encoded file content: %s", err.Error())
+		}
+
+		if !bytes.Equal(byt, commit.Files[file]) {
+			t.Fatal("Decoded file content doesn't match expected")
+		}
+	}))
+	defer server.Close()
+	target := NewAPIClient(server.URL, "test-project", fmt.Sprintf("%s:%s", testUser, testKey))
+	target.client = server.Client()
+
+	if err := target.Commit(commit); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestGet(t *testing.T) {
+	testUser := "test-user"
+	testKey := "test-key"
+	testData := []byte("hello test here")
+
+	// Setup test HTTP server/client
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Check authorization key
+		user, key, ok := req.BasicAuth()
+		if !ok {
+			t.Fatal("Invalid or empty HTTP Basic auth header received")
+		}
+		assertExpected(t, user, testUser, "Basic auth user doesn't match expected value")
+		assertExpected(t, key, testKey, "Basic auth password doesn't match expected value")
+
+		rw.Write(testData)
+	}))
+	defer server.Close()
+	target := NewAPIClient(server.URL, "test-project", fmt.Sprintf("%s:%s", testUser, testKey))
+	target.client = server.Client()
+
+	byt, err := target.Get(testKey, "main")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !bytes.Equal(byt, testData) {
+		t.Fatal("Expected file content is different from retrieved")
+	}
+}
+
+func TestFaultyServer(t *testing.T) {
+	// Mock server that just errors out
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	payload := targets.NewPayload("test-branch", "test-author <author@example.com>", "Hello")
+	payload.Files.Add(map[string][]byte{
+		"textfile.txt": []byte("test file"),
+	})
+
+	// Test with erroring server
+	target := NewAPIClient(server.URL, "test-project", "unused")
+	target.client = server.Client()
+
+	if _, err := target.Get("test", "main"); err == nil {
+		t.Fatal("Request supposed to error out but Get call exited successfully")
+	}
+
+	if err := target.Commit(payload); err == nil {
+		t.Fatal("Request supposed to error out but Commit call exited successfully")
+	}
+
+	// Test with unreacheable target
+	target = NewAPIClient("http://0.0.0.0", "test-project", "unused")
+	target.client = server.Client()
+	target.client.Timeout = time.Millisecond // Set a low timeout since we don't want this to work anyway
+
+	if _, err := target.Get("test", "main"); err == nil {
+		t.Fatal("Request supposed to error out but Get call exited successfully")
+	}
+
+	if err := target.Commit(payload); err == nil {
+		t.Fatal("Request supposed to error out but Commit call exited successfully")
+	}
+}


### PR DESCRIPTION
### Description

Add [GitHub](https://github.com/Neosperience/shipper/pull/5) as Git provider.

Additionally add default API endpoints for both GitHub and GitLab to their hosted versions

### References

Closes #3 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this or a different PR.
- [x] I have signed off my commits as required by the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] The correct base branch is being used, if not `main`

