### PR TITLE
Option to skip certificate validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--no-verify-tls` will make all HTTPS requests skip TLS cerficate validation (eg. for running selfsigned certificates)
+
+### Changed
+
+- Every HTTP request now uses the default Go transport options, most notably timeout is now 90 seconds instead of 30, plus a few extra sanity checks.
+
 ## [0.2.0] - 2022-02-28
 
 ### Added

--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -16,6 +18,12 @@ import (
 )
 
 func app(c *cli.Context) error {
+	// Modify default HTTP client transport to not check for certificates if asked to do so
+	insecureCert := c.Bool("no-verify-tls")
+	if insecureCert {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
 	// Create payload
 	payload := targets.NewPayload(c.String("repo-branch"), c.String("commit-author"), c.String("commit-message"))
 
@@ -155,6 +163,12 @@ func main() {
 				Usage:    "Container tag",
 				EnvVars:  []string{"SHIPPER_CONTAINER_TAG"},
 				Required: true,
+			},
+			&cli.BoolFlag{
+				Name:    "no-verify-tls",
+				Usage:   "If provided, skip X.509 certificate validation on HTTPS requests",
+				EnvVars: []string{"SHIPPER_NO_VERIFY_TLS"},
+				Value:   false,
 			},
 			// Helm options
 			&cli.StringFlag{

--- a/targets/bitbucket/bbcloud.go
+++ b/targets/bitbucket/bbcloud.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/neosperience/shipper/targets"
 )
@@ -23,10 +22,7 @@ type BitbucketCloudRepository struct {
 
 // NewCloudAPIClient creates a BitbucketCloudRepository instance
 func NewCloudAPIClient(projectID string, credentials string) *BitbucketCloudRepository {
-	var transport = &http.Transport{
-		IdleConnTimeout: 30 * time.Second,
-	}
-	var client = &http.Client{Transport: transport}
+	var client = &http.Client{}
 	return &BitbucketCloudRepository{
 		baseURI:     "https://api.bitbucket.org/2.0",
 		projectID:   projectID,

--- a/targets/github/github.go
+++ b/targets/github/github.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"time"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/neosperience/shipper/targets"
@@ -24,10 +23,7 @@ type GithubRepository struct {
 
 // NewAPIClient creates a GithubRepository instance
 func NewAPIClient(uri string, projectID string, credentials string) *GithubRepository {
-	var transport = &http.Transport{
-		IdleConnTimeout: 30 * time.Second,
-	}
-	var client = &http.Client{Transport: transport}
+	var client = &http.Client{}
 	return &GithubRepository{
 		baseURI:     uri,
 		projectID:   projectID,

--- a/targets/gitlab/gitlab.go
+++ b/targets/gitlab/gitlab.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"time"
 	"unicode/utf8"
 
 	jsoniter "github.com/json-iterator/go"
@@ -25,10 +24,7 @@ type GitlabRepository struct {
 
 // NewAPIClient creates a GitlabRepository instance
 func NewAPIClient(uri string, projectID string, key string) *GitlabRepository {
-	var transport = &http.Transport{
-		IdleConnTimeout: 30 * time.Second,
-	}
-	var client = &http.Client{Transport: transport}
+	var client = &http.Client{}
 	return &GitlabRepository{
 		baseURI:    uri,
 		projectID:  projectID,


### PR DESCRIPTION
### Description

Adds a flag to skip TLS certificate validation (for running selfhosted github/gitlab with selfsigned certs, for example).

### Testing

No test has been added for this since it's mostly a transport/defaults change.

### Checklist

- [x] I have added documentation for new/changed functionality in this or a different PR.
- [x] I have signed off my commits as required by the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] The correct base branch is being used, if not `main`

