### PR TITLE
Update multiple images at once

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Install tools
         run: |
           go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - run: go test -race ./...
       - name: Release
         uses: goreleaser/goreleaser-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for Gitea as git provider (`--repo-kind gitea`)
+- Added support for updating multiple images at once, either specifying `--container-image`, `--container-tag` (and other related tags) multiple times, or by using the environmental variables `CONTAINER_IMAGES` and `CONTAINER_TAGS` with comma-separated values. Multiple files can also be changed with one single run (resulting in a single commit).
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.17 as build-env
+FROM public.ecr.aws/docker/library/golang:1.18 as build-env
 
 WORKDIR /go/src/app
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ deploy-prod:
         --gitlab-project my-app/deployments
 ```
 
+### Updating multiple images at once
+
+Command line arguments `--container-image`, `--container-tag`, `--helm-values-file`, `--helm-image-path`, `--helm-tag-path` and `--kustomize-file` can be specified multiple times to update multiple images at once. If using the environment variables, these values are comma-separated (eg. `CONTAINER_IMAGES=image1,image2`).
+
+This is an example of updating multiple images at once:
+
+```bash
+shipper -p helm --helm-values-file helm/values.yml \
+  --helm-image-path image.repository --helm-tag-path image.tag --container-image img1 --container-tag tag1 \
+  --helm-image-path image2.repository --helm-tag-path image2.tag --container-image img2 --container-tag tag2 \
+  ... \
+  --repo-branch master --commit-author "Test" ...
+```
+
+You can mix & match which to specify once and which to specify many times, but every tag *must* be specified either 1 or N times, with some exceptions where closely-related tags must always be both specified the same amount of times, for example:
+
+- ✔️ one `--helm-values-file` but many `--helm-image-path` (all changes will be applied to the same YAML file)
+- ✔️ many `--helm-values-file` and `--helm-image-path` (every change will be applied to a specific file, the same file can be specified multiple times)
+- ❌ 3 instances of `--helm-image-path` but 2 instances of `--helm-values-file`
+- ❌ non-equal amount of `--container-image`, `--container-tag`, `--helm-image-path`, `--helm-tag-path`
+
 ## Provider notes
 
 ### GitLab

--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -199,14 +199,14 @@ func main() {
 				Name:     "container-image",
 				Aliases:  []string{"ci"},
 				Usage:    "Container image",
-				EnvVars:  []string{"SHIPPER_CONTAINER_IMAGE"},
+				EnvVars:  []string{"SHIPPER_CONTAINER_IMAGE", "SHIPPER_CONTAINER_IMAGES"},
 				Required: true,
 			},
 			&cli.StringSliceFlag{
 				Name:     "container-tag",
 				Aliases:  []string{"ct"},
 				Usage:    "Container tag",
-				EnvVars:  []string{"SHIPPER_CONTAINER_TAG"},
+				EnvVars:  []string{"SHIPPER_CONTAINER_TAG", "SHIPPER_CONTAINER_TAGS"},
 				Required: true,
 			},
 			&cli.BoolFlag{
@@ -220,20 +220,20 @@ func main() {
 				Name:    "helm-values-file",
 				Aliases: []string{"hpath"},
 				Usage:   "[helm] Path to values.yaml file",
-				EnvVars: []string{"SHIPPER_HELM_VALUES_FILE"},
+				EnvVars: []string{"SHIPPER_HELM_VALUES_FILE", "SHIPPER_HELM_VALUES_FILES"},
 			},
 			&cli.StringSliceFlag{
 				Name:    "helm-image-path",
 				Aliases: []string{"himg"},
 				Usage:   "[helm] Container image path",
-				EnvVars: []string{"SHIPPER_HELM_IMAGE_PATH"},
+				EnvVars: []string{"SHIPPER_HELM_IMAGE_PATH", "SHIPPER_HELM_IMAGE_PATHS"},
 				Value:   cli.NewStringSlice("image.repository"),
 			},
 			&cli.StringSliceFlag{
 				Name:    "helm-tag-path",
 				Aliases: []string{"htag"},
 				Usage:   "[helm] Container tag path",
-				EnvVars: []string{"SHIPPER_HELM_TAG_PATH"},
+				EnvVars: []string{"SHIPPER_HELM_TAG_PATH", "SHIPPER_HELM_TAG_PATHS"},
 				Value:   cli.NewStringSlice("image.tag"),
 			},
 			// Kustomize options
@@ -241,7 +241,7 @@ func main() {
 				Name:    "kustomize-file",
 				Aliases: []string{"kfile"},
 				Usage:   "[kustomize] Path to kustomization.yaml file",
-				EnvVars: []string{"SHIPPER_KUSTOMIZE_FILE"},
+				EnvVars: []string{"SHIPPER_KUSTOMIZE_FILE", "SHIPPER_KUSTOMIZE_FILES"},
 			},
 			// Gitlab options
 			&cli.StringFlag{
@@ -323,14 +323,14 @@ func main() {
 	check(app.Run(os.Args), "Fatal error")
 }
 
-func check(err error, format string, args ...interface{}) {
+func check(err error, format string, args ...any) {
 	if err != nil {
 		args = append(args, err.Error())
 		log.Fatalf(format+": %s", args...)
 	}
 }
 
-func assert(cond bool, format string, args ...interface{}) {
+func assert(cond bool, format string, args ...any) {
 	if !cond {
 		log.Fatalf(format, args...)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neosperience/shipper
 
-go 1.17
+go 1.18
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/patch/path.go
+++ b/patch/path.go
@@ -9,7 +9,7 @@ var (
 	ErrInvalidYAMLStructure = errors.New("found a value while traversing a tree")
 )
 
-func SetPath(root map[string]interface{}, path string, value interface{}) error {
+func SetPath(root map[string]any, path string, value any) error {
 	pieces := strings.Split(path, ".")
 	data := root
 	head, tail := pieces[:len(pieces)-1], pieces[len(pieces)-1]
@@ -17,10 +17,10 @@ func SetPath(root map[string]interface{}, path string, value interface{}) error 
 	for _, piece := range head {
 		_, ok := data[piece]
 		if !ok {
-			data[piece] = make(map[string]interface{})
+			data[piece] = make(map[string]any)
 		}
 		switch v := data[piece].(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			data = v
 		default:
 			return ErrInvalidYAMLStructure

--- a/patch/path_test.go
+++ b/patch/path_test.go
@@ -26,14 +26,14 @@ func TestSetPathExisting(t *testing.T) {
 		t.Fatalf("YAML encoding failed: %s", err.Error())
 	}
 
-	asMap := make(map[string]interface{})
+	asMap := make(map[string]any)
 	err = yaml.Unmarshal(byt, asMap)
 	if err != nil {
 		t.Fatalf("YAML decoding failed: %s", err.Error())
 	}
 
 	// Assert that decoding went fine
-	if asMap["nested"].(map[string]interface{})["value"] != "tochange" {
+	if asMap["nested"].(map[string]any)["value"] != "tochange" {
 		t.Fatal("Expected .Nested.Value value is different")
 	}
 
@@ -44,7 +44,7 @@ func TestSetPathExisting(t *testing.T) {
 	}
 
 	// Check that value was changed
-	if asMap["nested"].(map[string]interface{})["value"] != "changed" {
+	if asMap["nested"].(map[string]any)["value"] != "changed" {
 		t.Fatal("Expected .Nested.Value value is different")
 	}
 
@@ -55,13 +55,13 @@ func TestSetPathExisting(t *testing.T) {
 	}
 
 	// Check that value was changed
-	if asMap["nested"].(map[string]interface{})["other-value"] != "new-value" {
+	if asMap["nested"].(map[string]any)["other-value"] != "new-value" {
 		t.Fatal("New value not found or different")
 	}
 }
 
 func TestSetPathEmpty(t *testing.T) {
-	asMap := make(map[string]interface{})
+	asMap := make(map[string]any)
 
 	// Call SetPath on an existing tree
 	err := SetPath(asMap, "nested.value", "changed")
@@ -70,13 +70,13 @@ func TestSetPathEmpty(t *testing.T) {
 	}
 
 	// Check that value was changed
-	if asMap["nested"].(map[string]interface{})["value"] != "changed" {
+	if asMap["nested"].(map[string]any)["value"] != "changed" {
 		t.Fatal("Expected .Nested.Value value is different")
 	}
 }
 
 func TestSetPathInvalid(t *testing.T) {
-	asMap := make(map[string]interface{})
+	asMap := make(map[string]any)
 	asMap["nested"] = 12
 
 	// Call SetPath on an existing tree
@@ -91,7 +91,7 @@ func TestSetPathInvalid(t *testing.T) {
 }
 
 func BenchmarkSetPath(b *testing.B) {
-	asMap := make(map[string]interface{})
+	asMap := make(map[string]any)
 	err := SetPath(asMap, "nested.value", "new-value")
 	if err != nil {
 		b.Fatal("Failed to set initial value")

--- a/targets/gitea/gitea_test.go
+++ b/targets/gitea/gitea_test.go
@@ -81,7 +81,7 @@ func TestCommit(t *testing.T) {
 		}
 
 		_ = jsoniter.ConfigFastest.NewEncoder(rw).Encode(struct {
-			Commit interface{} `json:"commit"`
+			Commit any `json:"commit"`
 		}{
 			Commit: struct {
 				HTMLURL string `json:"html_url"`

--- a/targets/github/github_test.go
+++ b/targets/github/github_test.go
@@ -81,7 +81,7 @@ func TestCommit(t *testing.T) {
 		}
 
 		_ = jsoniter.ConfigFastest.NewEncoder(rw).Encode(struct {
-			Commit interface{} `json:"commit"`
+			Commit any `json:"commit"`
 		}{
 			Commit: struct {
 				HTMLURL string `json:"html_url"`

--- a/templater/helm/helm.go
+++ b/templater/helm/helm.go
@@ -24,7 +24,7 @@ type HelmProviderOptions struct {
 
 func UpdateHelmChart(repository targets.Repository, options HelmProviderOptions) (targets.FileList, error) {
 	original := make(map[string][]byte)
-	files := make(map[string]map[string]interface{})
+	files := make(map[string]map[string]any)
 	for _, update := range options.Updates {
 		if _, ok := files[update.ValuesFile]; !ok {
 			file, err := repository.Get(update.ValuesFile, options.Ref)
@@ -33,7 +33,7 @@ func UpdateHelmChart(repository targets.Repository, options HelmProviderOptions)
 			}
 
 			original[update.ValuesFile] = file
-			files[update.ValuesFile] = make(map[string]interface{})
+			files[update.ValuesFile] = make(map[string]any)
 			if err := yaml.Unmarshal(file, files[update.ValuesFile]); err != nil {
 				return nil, fmt.Errorf("could not parse YAML file %s: %w", update.ValuesFile, err)
 			}

--- a/templater/helm/helm.go
+++ b/templater/helm/helm.go
@@ -9,8 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type HelmProviderOptions struct {
-	Ref        string
+type HelmUpdate struct {
 	ValuesFile string
 	Image      string
 	ImagePath  string
@@ -18,34 +17,50 @@ type HelmProviderOptions struct {
 	TagPath    string
 }
 
+type HelmProviderOptions struct {
+	Ref     string
+	Updates []HelmUpdate
+}
+
 func UpdateHelmChart(repository targets.Repository, options HelmProviderOptions) (targets.FileList, error) {
-	file, err := repository.Get(options.ValuesFile, options.Ref)
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve values.yaml from repository: %w", err)
-	}
+	original := make(map[string][]byte)
+	files := make(map[string]map[string]interface{})
+	for _, update := range options.Updates {
+		if _, ok := files[update.ValuesFile]; !ok {
+			file, err := repository.Get(update.ValuesFile, options.Ref)
+			if err != nil {
+				return nil, fmt.Errorf("could not retrieve %s from repository: %w", update.ValuesFile, err)
+			}
 
-	values := make(map[string]interface{})
-	if err := yaml.Unmarshal(file, values); err != nil {
-		return nil, fmt.Errorf("could not parse values.yaml: %w", err)
-	}
-	if err := patch.SetPath(values, options.ImagePath, options.Image); err != nil {
-		return nil, fmt.Errorf("could not patch image for values.yaml: %w", err)
-	}
-	if err := patch.SetPath(values, options.TagPath, options.Tag); err != nil {
-		return nil, fmt.Errorf("could not patch image for values.yaml: %w", err)
-	}
+			original[update.ValuesFile] = file
+			files[update.ValuesFile] = make(map[string]interface{})
+			if err := yaml.Unmarshal(file, files[update.ValuesFile]); err != nil {
+				return nil, fmt.Errorf("could not parse YAML file %s: %w", update.ValuesFile, err)
+			}
+		}
 
-	byt, err := yaml.Marshal(values)
-	if err != nil {
-		return nil, fmt.Errorf("could not serialize modified file to YAML: %w", err)
-	}
-
-	if bytes.Equal(byt, file) {
-		return targets.FileList{}, nil
+		if err := patch.SetPath(files[update.ValuesFile], update.ImagePath, update.Image); err != nil {
+			return nil, fmt.Errorf("could not patch image for %s: %w", update.ValuesFile, err)
+		}
+		if err := patch.SetPath(files[update.ValuesFile], update.TagPath, update.Tag); err != nil {
+			return nil, fmt.Errorf("could not patch image for %s: %w", update.ValuesFile, err)
+		}
 	}
 
 	diff := make(targets.FileList)
-	diff[options.ValuesFile] = byt
+	for file, content := range files {
+		byt, err := yaml.Marshal(content)
+		if err != nil {
+			return nil, fmt.Errorf("could not serialize modified file to YAML: %w", err)
+		}
+
+		// Skip if there are no changes
+		if bytes.Equal(original[file], byt) {
+			continue
+		}
+
+		diff[file] = byt
+	}
 
 	return diff, nil
 }

--- a/templater/helm/helm_test.go
+++ b/templater/helm/helm_test.go
@@ -83,12 +83,16 @@ func testUpdateHelmChart(t *testing.T, file string) {
 	})
 
 	commitData, err := helm_templater.UpdateHelmChart(repo, helm_templater.HelmProviderOptions{
-		Ref:        "main",
-		ValuesFile: "path/to/values.yaml",
-		ImagePath:  "image.repository",
-		Image:      newImage,
-		TagPath:    "image.tag",
-		Tag:        newTag,
+		Ref: "main",
+		Updates: []helm_templater.HelmUpdate{
+			{
+				ValuesFile: "path/to/values.yaml",
+				ImagePath:  "image.repository",
+				Image:      newImage,
+				TagPath:    "image.tag",
+				Tag:        newTag,
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Failed updating values.yaml: %s", err)
@@ -135,12 +139,16 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with inexistant file
 	_, err := helm_templater.UpdateHelmChart(brokenrepo, helm_templater.HelmProviderOptions{
-		Ref:        "main",
-		ValuesFile: "inexistant-path/values.yaml",
-		ImagePath:  "image.repository",
-		Image:      "test",
-		TagPath:    "image.tag",
-		Tag:        "test",
+		Ref: "main",
+		Updates: []helm_templater.HelmUpdate{
+			{
+				ValuesFile: "inexistant-path/values.yaml",
+				ImagePath:  "image.repository",
+				Image:      "test",
+				TagPath:    "image.tag",
+				Tag:        "test",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file did not exist!")
@@ -152,12 +160,16 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with non-YAML file
 	_, err = helm_templater.UpdateHelmChart(brokenrepo, helm_templater.HelmProviderOptions{
-		Ref:        "main",
-		ValuesFile: "non-yaml/values.yaml",
-		ImagePath:  "image.repository",
-		Image:      "test",
-		TagPath:    "image.tag",
-		Tag:        "test",
+		Ref: "main",
+		Updates: []helm_templater.HelmUpdate{
+			{
+				ValuesFile: "non-yaml/values.yaml",
+				ImagePath:  "image.repository",
+				Image:      "test",
+				TagPath:    "image.tag",
+				Tag:        "test",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file is not a YAML file!")
@@ -165,12 +177,16 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with invalid image path
 	_, err = helm_templater.UpdateHelmChart(brokenrepo, helm_templater.HelmProviderOptions{
-		Ref:        "main",
-		ValuesFile: "broken-image/values.yaml",
-		ImagePath:  "image.name",
-		Image:      "test",
-		TagPath:    "tag.name",
-		Tag:        "test",
+		Ref: "main",
+		Updates: []helm_templater.HelmUpdate{
+			{
+				ValuesFile: "broken-image/values.yaml",
+				ImagePath:  "image.name",
+				Image:      "test",
+				TagPath:    "tag.name",
+				Tag:        "test",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file has an invalid format!")
@@ -182,12 +198,16 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with invalid tag path
 	_, err = helm_templater.UpdateHelmChart(brokenrepo, helm_templater.HelmProviderOptions{
-		Ref:        "main",
-		ValuesFile: "broken-tag/values.yaml",
-		ImagePath:  "image.name",
-		Image:      "test",
-		TagPath:    "tag.name",
-		Tag:        "test",
+		Ref: "main",
+		Updates: []helm_templater.HelmUpdate{
+			{
+				ValuesFile: "broken-tag/values.yaml",
+				ImagePath:  "image.name",
+				Image:      "test",
+				TagPath:    "tag.name",
+				Tag:        "test",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file has an invalid format!")
@@ -209,12 +229,16 @@ func TestUpdateHelmChartNoChanges(t *testing.T) {
 	})
 
 	commitData, err := helm_templater.UpdateHelmChart(repo, helm_templater.HelmProviderOptions{
-		Ref:        "main",
-		ValuesFile: "path/to/values.yaml",
-		ImagePath:  "image.repository",
-		Image:      "somerandom.tld/org/name",
-		TagPath:    "image.tag",
-		Tag:        "latest",
+		Ref: "main",
+		Updates: []helm_templater.HelmUpdate{
+			{
+				ValuesFile: "path/to/values.yaml",
+				ImagePath:  "image.repository",
+				Image:      "somerandom.tld/org/name",
+				TagPath:    "image.tag",
+				Tag:        "latest",
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Failed updating values.yaml: %s", err)

--- a/templater/kustomize/kustomize.go
+++ b/templater/kustomize/kustomize.go
@@ -8,79 +8,95 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type KustomizeProviderOptions struct {
-	Ref               string
+type KustomizeUpdate struct {
 	KustomizationFile string
 	Image             string
 	NewImage          string
 	NewTag            string
 }
 
+type KustomizeProviderOptions struct {
+	Ref     string
+	Updates []KustomizeUpdate
+}
+
 func UpdateKustomization(repository targets.Repository, options KustomizeProviderOptions) (targets.FileList, error) {
-	file, err := repository.Get(options.KustomizationFile, options.Ref)
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve values.yaml from repository: %w", err)
-	}
+	original := make(map[string][]byte)
+	files := make(map[string]map[string]interface{})
+	for _, update := range options.Updates {
+		if _, ok := files[update.KustomizationFile]; !ok {
+			file, err := repository.Get(update.KustomizationFile, options.Ref)
+			if err != nil {
+				return nil, fmt.Errorf("could not retrieve %s from repository: %w", update.KustomizationFile, err)
+			}
 
-	values := make(map[string]interface{})
-	if err := yaml.Unmarshal(file, values); err != nil {
-		return nil, fmt.Errorf("could not parse values.yaml: %w", err)
-	}
+			original[update.KustomizationFile] = file
+			files[update.KustomizationFile] = make(map[string]interface{})
+			if err := yaml.Unmarshal(file, files[update.KustomizationFile]); err != nil {
+				return nil, fmt.Errorf("could not parse YAML file %s: %w", update.KustomizationFile, err)
+			}
+		}
 
-	images, ok := values["images"]
-	if !ok {
-		images = []interface{}{}
-	}
-
-	// Make sure existing value is an array
-	imageList, ok := images.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("kustomization file .images field is not an array")
-	}
-
-	// Check for existing entries
-	found := false
-	for index := range imageList {
-		current, ok := imageList[index].(map[string]interface{})
+		values := files[update.KustomizationFile]
+		images, ok := values["images"]
 		if !ok {
-			return nil, fmt.Errorf("found invalid entry in image list")
+			images = []interface{}{}
 		}
-		if current["name"] == options.Image {
-			if options.NewImage != "" {
-				current["newImage"] = options.NewImage
-			}
-			if options.NewTag != "" {
-				current["newTag"] = options.NewTag
-			}
-			found = true
-			break
-		}
-	}
-	if !found {
-		newEntry := map[string]interface{}{
-			"name": options.Image,
-		}
-		if options.NewImage != "" {
-			newEntry["newImage"] = options.NewImage
-		}
-		if options.NewTag != "" {
-			newEntry["newTag"] = options.NewTag
-		}
-		imageList = append(imageList, newEntry)
-	}
-	values["images"] = imageList
 
-	byt, err := yaml.Marshal(values)
-	if err != nil {
-		return nil, fmt.Errorf("could not serialize modified file to YAML: %w", err)
-	}
+		// Make sure existing value is an array
+		imageList, ok := images.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("kustomization file .images field is not an array")
+		}
 
-	if bytes.Equal(byt, file) {
-		return targets.FileList{}, nil
+		// Check for existing entries
+		found := false
+		for index := range imageList {
+			current, ok := imageList[index].(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("found invalid entry in image list")
+			}
+			if current["name"] == update.Image {
+				if update.NewImage != "" {
+					current["newImage"] = update.NewImage
+				}
+				if update.NewTag != "" {
+					current["newTag"] = update.NewTag
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			newEntry := map[string]interface{}{
+				"name": update.Image,
+			}
+			if update.NewImage != "" {
+				newEntry["newImage"] = update.NewImage
+			}
+			if update.NewTag != "" {
+				newEntry["newTag"] = update.NewTag
+			}
+			imageList = append(imageList, newEntry)
+		}
+		values["images"] = imageList
+		files[update.KustomizationFile] = values
 	}
 
 	diff := make(targets.FileList)
-	diff[options.KustomizationFile] = byt
+	for file, values := range files {
+		byt, err := yaml.Marshal(values)
+		if err != nil {
+			return nil, fmt.Errorf("could not serialize modified file to YAML: %w", err)
+		}
+
+		// Skip if there are no changes
+		if bytes.Equal(original[file], byt) {
+			continue
+		}
+
+		diff[file] = byt
+	}
 
 	return diff, nil
 }

--- a/templater/kustomize/kustomize.go
+++ b/templater/kustomize/kustomize.go
@@ -22,7 +22,7 @@ type KustomizeProviderOptions struct {
 
 func UpdateKustomization(repository targets.Repository, options KustomizeProviderOptions) (targets.FileList, error) {
 	original := make(map[string][]byte)
-	files := make(map[string]map[string]interface{})
+	files := make(map[string]map[string]any)
 	for _, update := range options.Updates {
 		if _, ok := files[update.KustomizationFile]; !ok {
 			file, err := repository.Get(update.KustomizationFile, options.Ref)
@@ -31,7 +31,7 @@ func UpdateKustomization(repository targets.Repository, options KustomizeProvide
 			}
 
 			original[update.KustomizationFile] = file
-			files[update.KustomizationFile] = make(map[string]interface{})
+			files[update.KustomizationFile] = make(map[string]any)
 			if err := yaml.Unmarshal(file, files[update.KustomizationFile]); err != nil {
 				return nil, fmt.Errorf("could not parse YAML file %s: %w", update.KustomizationFile, err)
 			}
@@ -40,11 +40,11 @@ func UpdateKustomization(repository targets.Repository, options KustomizeProvide
 		values := files[update.KustomizationFile]
 		images, ok := values["images"]
 		if !ok {
-			images = []interface{}{}
+			images = []any{}
 		}
 
 		// Make sure existing value is an array
-		imageList, ok := images.([]interface{})
+		imageList, ok := images.([]any)
 		if !ok {
 			return nil, fmt.Errorf("kustomization file .images field is not an array")
 		}
@@ -52,7 +52,7 @@ func UpdateKustomization(repository targets.Repository, options KustomizeProvide
 		// Check for existing entries
 		found := false
 		for index := range imageList {
-			current, ok := imageList[index].(map[string]interface{})
+			current, ok := imageList[index].(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("found invalid entry in image list")
 			}
@@ -68,7 +68,7 @@ func UpdateKustomization(repository targets.Repository, options KustomizeProvide
 			}
 		}
 		if !found {
-			newEntry := map[string]interface{}{
+			newEntry := map[string]any{
 				"name": update.Image,
 			}
 			if update.NewImage != "" {

--- a/templater/kustomize/kustomize_test.go
+++ b/templater/kustomize/kustomize_test.go
@@ -51,11 +51,15 @@ func testUpdateKustomizationCommon(t *testing.T, kustomizeFile string) {
 	})
 
 	commitData, err := kustomize_templater.UpdateKustomization(repo, kustomize_templater.KustomizeProviderOptions{
-		Ref:               "dummy",
-		KustomizationFile: "path/to/kustomization.yaml",
-		Image:             newImage,
-		NewTag:            newTag,
-		NewImage:          newImagePath,
+		Ref: "dummy",
+		Updates: []kustomize_templater.KustomizeUpdate{
+			{
+				KustomizationFile: "path/to/kustomization.yaml",
+				Image:             newImage,
+				NewTag:            newTag,
+				NewImage:          newImagePath,
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Failed updating kustomization.yaml: %s", err.Error())
@@ -114,10 +118,14 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with inexistant file
 	_, err := kustomize_templater.UpdateKustomization(brokenrepo, kustomize_templater.KustomizeProviderOptions{
-		Ref:               "dummy",
-		KustomizationFile: "path/to/kustomization.yaml",
-		Image:             "test",
-		NewTag:            "tag",
+		Ref: "dummy",
+		Updates: []kustomize_templater.KustomizeUpdate{
+			{
+				KustomizationFile: "path/to/kustomization.yaml",
+				Image:             "test",
+				NewTag:            "tag",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file did not exist!")
@@ -129,10 +137,14 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with non-YAML file
 	_, err = kustomize_templater.UpdateKustomization(brokenrepo, kustomize_templater.KustomizeProviderOptions{
-		Ref:               "dummy",
-		KustomizationFile: "non-yaml/values.yaml",
-		Image:             "test",
-		NewTag:            "tag",
+		Ref: "dummy",
+		Updates: []kustomize_templater.KustomizeUpdate{
+			{
+				KustomizationFile: "non-yaml/values.yaml",
+				Image:             "test",
+				NewTag:            "tag",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file is not a YAML file!")
@@ -140,10 +152,14 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with invalid images path
 	_, err = kustomize_templater.UpdateKustomization(brokenrepo, kustomize_templater.KustomizeProviderOptions{
-		Ref:               "dummy",
-		KustomizationFile: "broken-images/values.yaml",
-		Image:             "test",
-		NewTag:            "tag",
+		Ref: "dummy",
+		Updates: []kustomize_templater.KustomizeUpdate{
+			{
+				KustomizationFile: "broken-images/values.yaml",
+				Image:             "test",
+				NewTag:            "tag",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file has an invalid format!")
@@ -151,10 +167,14 @@ func TestUpdateHelmChartFaultyRepository(t *testing.T) {
 
 	// Test with invalid images array type
 	_, err = kustomize_templater.UpdateKustomization(brokenrepo, kustomize_templater.KustomizeProviderOptions{
-		Ref:               "dummy",
-		KustomizationFile: "broken-images-value/values.yaml",
-		Image:             "test",
-		NewTag:            "tag",
+		Ref: "dummy",
+		Updates: []kustomize_templater.KustomizeUpdate{
+			{
+				KustomizationFile: "broken-images-value/values.yaml",
+				Image:             "test",
+				NewTag:            "tag",
+			},
+		},
 	})
 	if err == nil {
 		t.Fatal("Updating repo succeeded but the original file has an invalid format!")


### PR DESCRIPTION
### Description

Makes most command line flags be able to be specified multiple times to allow for bulk updates with a single commit

eg.

```bash
shipper -p helm --helm-values-file helm/values.yml \
  --helm-image-path image.repository --helm-tag-path image.tag --container-image test --container-tag mytag \
  --helm-image-path image2.repository --helm-tag-path image2.tag --container-image othertest --container-tag othertag \
  --repo-kind gitea --repo-branch master --commit-author "Test"
```

You can mix & match which to specify once and which to specify many times, but every tag *must* be specified either 1 or N times, with some exceptions where some paired tags must always be both specified the same amount of times, here's some examples:

  - ✔️ one `--helm-values-file` but many `--helm-image-path` (all changes will be applied to the same YAML file)
  - ✔️ many `--helm-values-file` and `--helm-image-path` (every change will be applied to a specific file, the same file can be specified multiple times)
  - ❌ 3 instances of `--helm-image-path` but 2 instances of `--helm-values-file`
  - ❌ non-same amount of `--container-image`, `--container-tag`, `--helm-image-path`, `--helm-tag-path`

### References

Closes #10 

### Testing

- [x] This change updates test to run with new internal APIs
- [x] This change adds new tests for new edge cases

### Checklist

- [x] I have added documentation for new/changed functionality in this or a different PR.
- [x] I have signed off my commits as required by the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] The correct base branch is being used, if not `main`

