### PR TITLE
Add JSON templater

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ You can mix & match which to specify once and which to specify many times, but e
 - ❌ 3 instances of `--helm-image-path` but 2 instances of `--helm-values-file`
 - ❌ non-equal amount of `--container-image`, `--container-tag`, `--helm-image-path`, `--helm-tag-path`
 
+## Available templaters
+
+### Helm
+
+The Helm templater is meant to be used on Helm values.yaml files. For each image to update, you must specify a value for each of the following:
+
+ - `--helm-values-file` / `SHIPPER_HELM_VALUES_FILES`: Path to the Helm values.yaml file to modify
+ - `--helm-image-path` / `SHIPPER_HELM_IMAGE_PATHS`: YAML field in the Helm values.yaml file to modify with the specified image repository, using dot notation for nested fields (eg. `image.repository`)
+ - `--helm-tag-path` / `SHIPPER_HELM_TAG_PATHS`: YAML field in the Helm values.yaml file to modify with the specified image tag, using dot notation for nested fields (eg. `image.tag`)
+
+### Kustomize
+
+The Kustomize templater is meant to be used on kustomization.yaml files using the `images` list format like in [this example](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/image.md).
+
+To use it, you must specify the following, either once or for each image/tag pair:
+
+ - `--kustomize-file` / `SHIPPER_KUSTOMIZE_FILES`: Path to the kustomization.yaml file to modify
+
+### JSON
+
+The JSON templater is meant for flat JSON files such as CDK context files (`cdk.json`).
+
+When using JSON, the `--image` argument will be used as the key to update in the JSON file, while the `--tag` argument will be used as the value. You will also need to specify the following value, either once or for each image/tag pair:
+
+ - `--json-file` / `SHIPPER_JSON_FILES`: Path to the JSON file to modify
+
 ## Provider notes
 
 ### GitLab
@@ -85,7 +111,6 @@ You can mix & match which to specify once and which to specify many times, but e
 - When creating a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for shipper, only the permissions `repo` is needed.
 - The author string MUST be in the `John Doe <john.doe@example.com>` format or the commit will fail.
 - The GitHub Cloud API endpoint is `https://api.github.com`, however GitHub Enterprise Server will have something more akin to `https://HOSTNAME/api/v3`
-
 
 ### Bitbucket cloud
 

--- a/templater/json/json.go
+++ b/templater/json/json.go
@@ -1,0 +1,60 @@
+package json_templater
+
+import (
+	"bytes"
+	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/neosperience/shipper/targets"
+)
+
+type FileUpdate struct {
+	File string
+	Path string
+	Tag  string
+}
+
+type JSONProviderOptions struct {
+	Ref     string
+	Updates []FileUpdate
+}
+
+func UpdateJSONFile(repository targets.Repository, options JSONProviderOptions) (targets.FileList, error) {
+	original := make(map[string][]byte)
+	files := make(map[string]map[string]any)
+	for _, update := range options.Updates {
+		if _, ok := files[update.File]; !ok {
+			file, err := repository.Get(update.File, options.Ref)
+			if err != nil {
+				return nil, fmt.Errorf("could not retrieve %s from repository: %w", update.File, err)
+			}
+
+			original[update.File] = file
+			data := make(map[string]any)
+			if err := jsoniter.ConfigDefault.Unmarshal(file, &data); err != nil {
+				return nil, fmt.Errorf("could not parse JSON file %s: %w", update.File, err)
+			}
+			files[update.File] = data
+		}
+
+		// Update the file
+		files[update.File][update.Path] = update.Tag
+	}
+
+	diff := make(targets.FileList)
+	for file, content := range files {
+		byt, err := jsoniter.ConfigDefault.MarshalIndent(content, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("could not serialize modified file to JSON: %w", err)
+		}
+
+		// Skip if there are no changes
+		if bytes.Equal(original[file], byt) {
+			continue
+		}
+
+		diff[file] = byt
+	}
+
+	return diff, nil
+}

--- a/templater/json/json_test.go
+++ b/templater/json/json_test.go
@@ -1,0 +1,191 @@
+package json_templater_test
+
+import (
+	"errors"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/neosperience/shipper/targets"
+
+	json_templater "github.com/neosperience/shipper/templater/json"
+)
+
+const testJSON = `{
+	"test": "field",
+	"nested": {
+		"test": "field"
+	},
+	"fake.nested": "tag",
+	"image.env=build": "old"
+}`
+
+func testUpdateJSONFile(t *testing.T, file string) {
+	imagePath := "image.env=build"
+	newTag := "2022-02-22"
+
+	repo := targets.NewInMemoryRepository(targets.FileList{
+		"path/to/cdk.json": []byte(file),
+	})
+
+	commitData, err := json_templater.UpdateJSONFile(repo, json_templater.JSONProviderOptions{
+		Ref: "main",
+		Updates: []json_templater.FileUpdate{
+			{
+				File: "path/to/cdk.json",
+				Path: imagePath,
+				Tag:  newTag,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed updating cdk.json: %s", err)
+	}
+
+	val, ok := commitData["path/to/cdk.json"]
+	if !ok {
+		t.Fatal("Expected cdk.json to be modified but wasn't found")
+	}
+
+	// Re-parse JSON
+	var parsed struct {
+		Image string `json:"image.env=build"`
+	}
+	err = jsoniter.ConfigDefault.Unmarshal(val, &parsed)
+	if err != nil {
+		t.Fatalf("Failed to parse committed JSON: %s", err.Error())
+	}
+	if parsed.Image != newTag {
+		t.Fatal("Image tag was not set to the new expected value")
+	}
+}
+
+func TestUpdateJSONFileExisting(t *testing.T) {
+	testUpdateJSONFile(t, testJSON)
+}
+
+func TestUpdateJSONFileEmpty(t *testing.T) {
+	testUpdateJSONFile(t, `{}`)
+}
+
+func TestUpdateHelmChartFaultyRepository(t *testing.T) {
+	brokenrepo := targets.NewInMemoryRepository(targets.FileList{
+		"non-json/cdk.json": []byte{0xff, 0xd8, 0xff, 0xe0},
+	})
+
+	// Test with inexistant file
+	_, err := json_templater.UpdateJSONFile(brokenrepo, json_templater.JSONProviderOptions{
+		Ref: "main",
+		Updates: []json_templater.FileUpdate{
+			{
+				File: "inexistant-path/cdk.json",
+				Path: "image",
+				Tag:  "test",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Updating repo succeeded but the original file did not exist!")
+	} else {
+		if !errors.Is(err, targets.ErrFileNotFound) {
+			t.Fatalf("Unexpected error: %s", err.Error())
+		}
+	}
+
+	// Test with non-JSON file
+	_, err = json_templater.UpdateJSONFile(brokenrepo, json_templater.JSONProviderOptions{
+		Ref: "main",
+		Updates: []json_templater.FileUpdate{
+			{
+				File: "non-json/cdk.json",
+				Path: "image",
+				Tag:  "test",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Updating repo succeeded but the original file is not a JSON file!")
+	}
+}
+
+func TestUpdateJSONNoChanges(t *testing.T) {
+	file := `{
+  "image": "latest"
+}`
+	repo := targets.NewInMemoryRepository(targets.FileList{
+		"path/to/cdk.json": []byte(file),
+	})
+
+	commitData, err := json_templater.UpdateJSONFile(repo, json_templater.JSONProviderOptions{
+		Ref: "main",
+		Updates: []json_templater.FileUpdate{
+			{
+				File: "path/to/cdk.json",
+				Path: "image",
+				Tag:  "latest",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed updating cdk.json: %s", err)
+	}
+
+	if len(commitData) > 0 {
+		t.Fatalf("Found %d changes but commit was expected to be empty", len(commitData))
+	}
+}
+
+func TestUpdateMultipleImages(t *testing.T) {
+	repo := targets.NewInMemoryRepository(targets.FileList{
+		"path/to/cdk.json":          []byte(`{"image": "latest"}`),
+		"path/to/other-values.json": []byte(`{}`),
+	})
+
+	updates := []json_templater.FileUpdate{
+		{
+			File: "path/to/cdk.json",
+			Path: "image",
+			Tag:  "latest",
+		},
+		{
+			File: "path/to/other-values.json",
+			Path: "image",
+			Tag:  "new",
+		},
+	}
+
+	commitData, err := json_templater.UpdateJSONFile(repo, json_templater.JSONProviderOptions{
+		Ref:     "main",
+		Updates: updates,
+	})
+	if err != nil {
+		t.Fatalf("Failed updating JSON files: %s", err)
+	}
+
+	valuesFile, ok := commitData["path/to/cdk.json"]
+	if !ok {
+		t.Fatal("Failed to find cdk.json in commit data")
+	}
+
+	var parsedValues struct {
+		Image string `json:"image"`
+	}
+	err = jsoniter.ConfigFastest.Unmarshal(valuesFile, &parsedValues)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal cdk.json: %s", err)
+	}
+	if parsedValues.Image != updates[0].Tag {
+		t.Fatalf("Expected first image to be tagged %s but got %s", updates[0].Tag, parsedValues.Image)
+	}
+
+	otherValuesFile, ok := commitData["path/to/other-values.json"]
+	if !ok {
+		t.Fatal("Failed to find other-values.json in commit data")
+	}
+	err = jsoniter.ConfigFastest.Unmarshal(otherValuesFile, &parsedValues)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal other-values.json: %s", err)
+	}
+	if parsedValues.Image != updates[1].Tag {
+		t.Fatalf("Expected second image to be tagged %s but got %s", updates[1].Tag, parsedValues.Image)
+	}
+}


### PR DESCRIPTION
### Description

Add JSON templater for flat JSON dictionaries (such as CDK context files).

Unlike kustomize/helm, this does not support nested structures (if you need it, open an issue with a proposal).

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this or a different PR.
- [x] I have signed off my commits as required by the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] The correct base branch is being used, if not `main`

